### PR TITLE
aboutページをSSGで事前に生成するように修正

### DIFF
--- a/src/components/organisms/MarkdownContentsComponent.tsx
+++ b/src/components/organisms/MarkdownContentsComponent.tsx
@@ -5,25 +5,14 @@ import remarkGfm from 'remark-gfm';
 import CodeBlockComponent from '@/components/organisms/CodeBlockComponent';
 
 type Props = {
-  fineName: string;
+  markDownContents: string;
 };
 
 export const MarkdownContentsComponent = (props: Props) => {
-  const [markdownContents, setMarkdownContents] = useState('');
-
-  useEffect(() => {
-    const fetchMarkdown = async () => {
-      const md = await fetch('/markdownContents/' + props.fineName);
-      const text = await md.text();
-      setMarkdownContents(text);
-    };
-    fetchMarkdown();
-  }, [props]);
-
   return (
     <div className='prose prose-xl mx-auto my-12'>
       <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]} components={{ code: CodeBlockComponent }}>
-        {markdownContents}
+        {props.markDownContents}
       </ReactMarkdown>
     </div>
   );

--- a/src/pages/about/index.tsx
+++ b/src/pages/about/index.tsx
@@ -1,8 +1,25 @@
-import { NextPage } from 'next';
+import { NextPage, GetStaticProps } from 'next';
 import { MarkdownContentsComponent } from '@/components/organisms/MarkdownContentsComponent';
+import fs from 'fs';
+import path from 'path';
 
-const AboutPage: NextPage = () => {
-  return <MarkdownContentsComponent fineName='about.md' />;
+type Props = {
+  markdownText: string;
 };
 
+const AboutPage: NextPage<Props> = ({ markdownText }: Props) => {
+  return <MarkdownContentsComponent markDownContents={markdownText} />;
+};
+
+const getStaticProps: GetStaticProps<Props> = async () => {
+  const filePath = path.join(process.cwd(), 'public/markdownContents/about.md');
+  const markdownText = fs.readFileSync(filePath, 'utf-8');
+  return {
+    props: {
+      markdownText,
+    },
+  };
+};
+
+export { getStaticProps };
 export default AboutPage;


### PR DESCRIPTION
# 事前確認

-   [x] PR前に動作確認をしたか
-   [x] ビルドエラー/ESLintエラーは起きていないか
-   [x] [開発ルール](https://daydule.atlassian.net/wiki/spaces/DAYDULE/pages/9765029)を守って実装しているか

~-   [ ] 単体テストが全てOKになっているか~（現状はフロントエンドの単体テストを実行できていないため）

-   [x] 機密情報を含んでいないか
-   [x] 最新の`develop`ブランチを反映しているか

# レビュワーによる動作確認

- [x] @Mellbrother 
- [x] @kzk27 

# やったこと<!-- このプルリクエストでやったことを書く -->
- MarkdownContentsComponentで行なっていたマークダウンファイルの取得処理をaboutページ側に移動
  [コメント](https://daydule.atlassian.net/browse/DAYD-844?focusedCommentId=10207) に内容記載
- SSGでビルド時にaboutページが生成さえるよう修正
　 (javascriptをdisableにしてもコンテンツが確認できる)

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->
特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->
特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->
[各種レンダリングについて](https://daydule.atlassian.net/l/cp/7xfUfy6o)　開発Tipsに記載
