### PR TITLE
DAYD-849 エラーアラート表示時の余白調整

### DIFF
--- a/src/components/atoms/AlertComponent.tsx
+++ b/src/components/atoms/AlertComponent.tsx
@@ -4,4 +4,4 @@ type Props = {
   text: string;
 };
 
-export const AlertComponent = (props: Props) => <p className='text-sm text-red-600'>{props.text}</p>;
+export const AlertComponent = (props: Props) => <p className='text-sm text-red-600 h-full'>{props.text}</p>;

--- a/src/components/organisms/LoginComponent.tsx
+++ b/src/components/organisms/LoginComponent.tsx
@@ -71,10 +71,14 @@ export const LoginComponent = () => {
               setter={setEmail}
             />
           </div>
-          <div className='mx-auto xl:w-3/5 w-4/5'>{validation.email && <AlertComponent text={validation.email} />}</div>
+          <div className={'mx-auto xl:w-3/5 w-4/5' + (validation.email ? ' h-6' : '')}>
+            {validation.email && <AlertComponent text={validation.email} />}
+          </div>
           <div
             className={
-              'mt-6 mx-auto xl:w-3/5 w-4/5' + (validation.password ? ' border-2 border-solid border-red-600' : '')
+              'mx-auto xl:w-3/5 w-4/5' +
+              (validation.password ? ' border-2 border-solid border-red-600' : '') +
+              (validation.email ? '' : ' mt-6')
             }
           >
             <InputWithIconComponent<string>
@@ -87,10 +91,10 @@ export const LoginComponent = () => {
               setter={setPassword}
             />
           </div>
-          <div className='mx-auto xl:w-3/5 w-4/5'>
+          <div className={'mx-auto xl:w-3/5 w-4/5 ' + (validation.password ? ' h-6' : '')}>
             {validation.password && <AlertComponent text={validation.password} />}
           </div>
-          <div className='mt-6 text-center mx-auto xl:w-1/5 w-2/5'>
+          <div className={'text-center mx-auto xl:w-1/5 w-2/5 ' + (validation.password ? '' : ' mt-6')}>
             <ButtonComponent type='submit' children='ログイン' />
           </div>
         </form>

--- a/src/components/organisms/SignupComponent.tsx
+++ b/src/components/organisms/SignupComponent.tsx
@@ -71,10 +71,14 @@ export const SignupComponent = () => {
               setter={setEmail}
             />
           </div>
-          <div className='mx-auto xl:w-3/5 w-4/5'>{validation.email && <AlertComponent text={validation.email} />}</div>
+          <div className={'mx-auto xl:w-3/5 w-4/5' + (validation.email ? ' h-6' : '')}>
+            {validation.email && <AlertComponent text={validation.email} />}
+          </div>
           <div
             className={
-              'mt-6 mx-auto xl:w-3/5 w-4/5' + (validation.password ? ' border-2 border-solid border-red-600' : '')
+              'mx-auto xl:w-3/5 w-4/5' +
+              (validation.password ? ' border-2 border-solid border-red-600' : '') +
+              (validation.email ? '' : ' mt-6')
             }
           >
             <InputWithIconComponent<string>
@@ -87,13 +91,14 @@ export const SignupComponent = () => {
               setter={setPassword}
             />
           </div>
-          <div className='mx-auto xl:w-3/5 w-4/5'>
+          <div className={'mx-auto xl:w-3/5 w-4/5' + (validation.password ? ' h-6' : '')}>
             {validation.password && <AlertComponent text={validation.password} />}
           </div>
           <div
             className={
-              'mt-6 mx-auto xl:w-3/5 w-4/5' +
-              (validation.passwordConfirmation ? ' border-2 border-solid border-red-600' : '')
+              'mx-auto xl:w-3/5 w-4/5 ' +
+              (validation.passwordConfirmation ? 'border-2 border-solid border-red-600' : '') +
+              (validation.password ? '' : ' mt-6')
             }
           >
             <InputWithIconComponent<string>
@@ -106,10 +111,10 @@ export const SignupComponent = () => {
               setter={setPasswordConfirmation}
             />
           </div>
-          <div className='mx-auto xl:w-3/5 w-4/5'>
+          <div className={'mx-auto xl:w-3/5 w-4/5 ' + (validation.passwordConfirmation ? 'h-6' : '')}>
             {validation.passwordConfirmation && <AlertComponent text={validation.passwordConfirmation} />}
           </div>
-          <div className='mt-6 mb-4 text-center mx-auto xl:w-1/5 w-2/5'>
+          <div className={'mb-4 text-center mx-auto xl:w-1/5 w-2/5' + (validation.passwordConfirmation ? '' : ' mt-6')}>
             <ButtonComponent type='submit' children='サインアップ' />
           </div>
         </form>


### PR DESCRIPTION
# 事前確認

-   [x] PR前に動作確認をしたか
-   [ ] ビルドエラー/ESLintエラーは起きていないか
-   [x] [開発ルール](https://daydule.atlassian.net/wiki/spaces/DAYDULE/pages/9765029)を守って実装しているか

~-   [ ] 単体テストが全てOKになっているか~（現状はフロントエンドの単体テストを実行できていないため）

-   [x] 機密情報を含んでいないか
-   [x] 最新の`develop`ブランチを反映しているか

# レビュワーによる動作確認

- [x] @atoook 
- [ ] @tom-takeru 

# やったこと<!-- このプルリクエストでやったことを書く -->
ログインやサインアップ時にエラーアラートが表示された場合、余分な余白が存在するのでボタンの位置がずれてしまう現象が発生したいたので修正

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->
ログイン・サインアップ以外のフォーム

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->
Buildエラー/lintエラーについては[こちら](https://daydule.atlassian.net/browse/DAYD-856)のチケットにて修正予定

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->
特になし
