### PR TITLE
DAYD-867 本番環境でスタイルが崩れる問題を解消

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,7 +4,7 @@ module.exports = {
       {
         source: '/',
         destination: '/about',
-        permanent: true,
+        permanent: false,
       },
     ];
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "eslint-plugin-tailwindcss": "^3.13.0",
         "postcss": "^8.4.20",
         "prettier": "^2.8.1",
+        "tailwind-merge": "^1.14.0",
         "tailwindcss": "^3.2.4",
         "typescript": "4.9.4"
       }
@@ -2122,9 +2123,9 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -2201,9 +2202,9 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -5945,9 +5946,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -6249,6 +6250,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-1.14.0.tgz",
+      "integrity": "sha512-3mFKyCo/MBcgyOTlrY8T7odzZFx+w+qKSMAmdFzRvqBfLlSigU6TZnlFHK0lkMwj9Bj8OYU+9yW9lmGuS0QEnQ==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {
@@ -6831,9 +6842,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-tailwindcss": "^3.13.0",
     "postcss": "^8.4.20",
     "prettier": "^2.8.1",
+    "tailwind-merge": "^1.14.0",
     "tailwindcss": "^3.2.4",
     "typescript": "4.9.4"
   },

--- a/src/components/atoms/ButtonComponent.tsx
+++ b/src/components/atoms/ButtonComponent.tsx
@@ -1,4 +1,5 @@
 import { MouseEventHandler, ReactNode } from 'react';
+import { twMerge } from 'tailwind-merge';
 
 type Props = {
   type: 'button' | 'submit' | 'reset';
@@ -7,16 +8,13 @@ type Props = {
   handleClick?: MouseEventHandler<HTMLButtonElement>;
 };
 
-export const ButtonComponent = (props: Props) => (
-  <div className='relative'>
-    <button
-      className={
-        props.extraClassName + ' ' + 'rounded-lg w-full bg-indigo-700 p-2 font-bold text-white hover:bg-blue-700'
-      }
-      type={props.type}
-      onClick={props.handleClick}
-    >
-      {props.children}
-    </button>
-  </div>
-);
+export const ButtonComponent = (props: Props) => {
+  const baseClassName = 'rounded-lg w-full bg-indigo-700 p-2 font-bold text-white hover:bg-blue-700';
+  return (
+    <div className='relative'>
+      <button className={twMerge(baseClassName, props.extraClassName)} type={props.type} onClick={props.handleClick}>
+        {props.children}
+      </button>
+    </div>
+  );
+};

--- a/src/components/atoms/ButtonWithIconComponent.tsx
+++ b/src/components/atoms/ButtonWithIconComponent.tsx
@@ -1,5 +1,6 @@
 import { MouseEventHandler, ReactNode } from 'react';
 import { IconContext } from 'react-icons/lib';
+import { twMerge } from 'tailwind-merge';
 
 type Props = {
   type: 'button' | 'submit' | 'reset';
@@ -9,17 +10,20 @@ type Props = {
   handleClick?: MouseEventHandler<HTMLButtonElement>;
 };
 
-export const ButtonWithIconComponent = (props: Props) => (
-  <div className='relative'>
-    <button type={props.type} onClick={props.handleClick}>
-      <IconContext.Provider
-        value={{
-          size: (props?.size ? props.size : 1.5) + 'rem',
-          className: props.extraClassName + ' ' + 'pt-1 text-black text-opacity-20 hover:text-opacity-100',
-        }}
-      >
-        {props.icon}
-      </IconContext.Provider>
-    </button>
-  </div>
-);
+export const ButtonWithIconComponent = (props: Props) => {
+  const baseClassName = 'pt-1 text-black text-opacity-20 hover:text-opacity-100';
+  return (
+    <div className='relative'>
+      <button type={props.type} onClick={props.handleClick}>
+        <IconContext.Provider
+          value={{
+            size: (props?.size ? props.size : 1.5) + 'rem',
+            className: twMerge(baseClassName, props.extraClassName),
+          }}
+        >
+          {props.icon}
+        </IconContext.Provider>
+      </button>
+    </div>
+  );
+};

--- a/src/components/atoms/ButtonWithOptionComponent.tsx
+++ b/src/components/atoms/ButtonWithOptionComponent.tsx
@@ -1,6 +1,7 @@
 import { MouseEventHandler, ReactNode, useState } from 'react';
 import { IconContext } from 'react-icons';
 import { AiFillCaretDown } from 'react-icons/ai';
+import { twMerge } from 'tailwind-merge';
 
 type Props = {
   typeForMainButton: 'button' | 'submit' | 'reset';
@@ -11,23 +12,26 @@ type Props = {
   handleClickOption?: MouseEventHandler<HTMLButtonElement>;
 };
 
-export const ButtonWithOptionComponent = (props: Props) => (
-  <div className={props.extraClassName + ' ' + 'flex'}>
-    <button
-      className='w-5/6 rounded-l-lg border-r-2 border-r-white bg-indigo-700 p-2 font-bold text-white hover:bg-blue-700'
-      type={props.typeForMainButton}
-      onClick={props.handleClick}
-    >
-      {props.children}
-    </button>
-    <button
-      className='w-1/6 rounded-r-lg bg-indigo-700 font-bold text-white hover:bg-blue-700'
-      type={props.typeForOptionButton}
-      onClick={props.handleClickOption}
-    >
-      <IconContext.Provider value={{ size: '1.5rem', className: 'mx-auto' }}>
-        <AiFillCaretDown />
-      </IconContext.Provider>
-    </button>
-  </div>
-);
+export const ButtonWithOptionComponent = (props: Props) => {
+  const baseClassName = 'flex';
+  return (
+    <div className={twMerge(baseClassName, props.extraClassName)}>
+      <button
+        className='w-5/6 rounded-l-lg border-r-2 border-r-white bg-indigo-700 p-2 font-bold text-white hover:bg-blue-700'
+        type={props.typeForMainButton}
+        onClick={props.handleClick}
+      >
+        {props.children}
+      </button>
+      <button
+        className='w-1/6 rounded-r-lg bg-indigo-700 font-bold text-white hover:bg-blue-700'
+        type={props.typeForOptionButton}
+        onClick={props.handleClickOption}
+      >
+        <IconContext.Provider value={{ size: '1.5rem', className: 'mx-auto' }}>
+          <AiFillCaretDown />
+        </IconContext.Provider>
+      </button>
+    </div>
+  );
+};

--- a/src/components/atoms/CheckBoxComponent.tsx
+++ b/src/components/atoms/CheckBoxComponent.tsx
@@ -14,14 +14,10 @@ export const CheckBoxComponent = (props: Props) => {
         name={props.name}
         type='checkbox'
         checked={props.value}
-        className='my-auto block h-4 w-4 rounded border-gray-300 bg-gray-100 text-blue-600 focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:ring-offset-gray-800 dark:focus:ring-blue-600'
+        className='my-auto block h-4 w-4 rounded border-gray-300 bg-gray-100 text-blue-600 focus:ring-2 focus:ring-blue-500'
         onChange={props.handleChange}
       />
-      <label
-        htmlFor={props.id}
-        className='ml-2 block text-sm font-medium text-gray-900 dark:text-gray-300'
-        children={props.title}
-      />
+      <label htmlFor={props.id} className='ml-2 block text-sm font-medium text-gray-900' children={props.title} />
     </div>
   );
 };

--- a/src/components/atoms/InputWithIconComponent.tsx
+++ b/src/components/atoms/InputWithIconComponent.tsx
@@ -7,7 +7,7 @@ type Props = {
   type?: 'text' | 'password' | 'number' | undefined;
   placeholder?: string;
   icon: ReactNode;
-  extraClassName?: string | undefined;
+  extraClassName?: string;
   customRef: RefObject<HTMLInputElement>;
 };
 

--- a/src/components/atoms/InputWithIconComponent.tsx
+++ b/src/components/atoms/InputWithIconComponent.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, RefObject } from 'react';
 import { IconContext } from 'react-icons/lib';
+import { twMerge } from 'tailwind-merge';
 
 type Props = {
   id: string;
@@ -12,6 +13,7 @@ type Props = {
 };
 
 export const InputWithIconComponent = (props: Props) => {
+  const baseClassName = 'w-full border border-black text-base block pl-10 h-12';
   return (
     <>
       <div className='relative'>
@@ -24,7 +26,7 @@ export const InputWithIconComponent = (props: Props) => {
           id={props.id}
           name={props.name}
           type={props.type}
-          className={props.extraClassName + ' ' + 'w-full border border-black text-base block pl-10 p-2.5 h-12'}
+          className={twMerge(baseClassName, props.extraClassName)}
           placeholder={props.placeholder}
           ref={props.customRef}
         />

--- a/src/components/atoms/LinkComponent.tsx
+++ b/src/components/atoms/LinkComponent.tsx
@@ -3,14 +3,11 @@ import { ReactNode } from 'react';
 type Props = {
   href: string;
   text?: string;
-  extraClassName?: string;
 };
 
 export const LinkComponent = (props: Props) => (
   <Link
-    className={
-      props.extraClassName + ' ' + 'text-blue-600 transition duration-100 hover:text-indigo-500 active:text-indigo-600 '
-    }
+    className={'text-blue-600 transition duration-100 hover:text-indigo-500 active:text-indigo-600'}
     href={props.href}
   >
     {props.text}

--- a/src/components/atoms/SimpleInputComponent.tsx
+++ b/src/components/atoms/SimpleInputComponent.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, forwardRef } from 'react';
 import { IconContext } from 'react-icons/lib';
+import { twMerge } from 'tailwind-merge';
 
 type Props = {
   id: string;
@@ -17,6 +18,7 @@ export const SimpleInputComponent = forwardRef((props: Props, ref: React.Ref<HTM
     props.setter(event.target.value);
   };
 
+  const baseClassName = 'block h-8 w-full rounded-lg border border-gray-200 p-2.5 text-base shadow-md';
   return (
     <div className='relative'>
       <input
@@ -25,9 +27,7 @@ export const SimpleInputComponent = forwardRef((props: Props, ref: React.Ref<HTM
         name={props.name}
         type={props.type}
         value={props.value}
-        className={
-          props.extraClassName + ' ' + 'w-full border border-gray-200 shadow-md rounded-lg text-base block p-2.5 h-8'
-        }
+        className={twMerge(baseClassName, props.extraClassName)}
         placeholder={props.placeholder}
         onChange={handleChange}
       />

--- a/src/components/atoms/SimpleInputComponent.tsx
+++ b/src/components/atoms/SimpleInputComponent.tsx
@@ -7,7 +7,7 @@ type Props = {
   type?: 'text' | 'password' | 'number' | undefined;
   value: string;
   placeholder?: string;
-  extraClassName?: string | undefined;
+  extraClassName?: string;
   setter: React.Dispatch<React.SetStateAction<string>>;
 };
 

--- a/src/components/atoms/TextAreaComponent.tsx
+++ b/src/components/atoms/TextAreaComponent.tsx
@@ -1,3 +1,5 @@
+import { twMerge } from 'tailwind-merge';
+
 type Props = {
   id: string;
   name: string;
@@ -8,15 +10,14 @@ type Props = {
 };
 
 export const TextAreaComponent = (props: Props) => {
+  const baseClassName = 'w-full border border-gray-200 shadow-md rounded-lg text-base block p-2.5 h-8';
   return (
     <div className='relative'>
       <textarea
         id={props.id}
         name={props.name}
         value={props.value}
-        className={
-          props.extraClassName + ' ' + 'w-full border border-gray-200 shadow-md rounded-lg text-base block p-2.5 h-8'
-        }
+        className={twMerge(baseClassName, props.extraClassName)}
         placeholder={props.placeholder}
         onChange={props.handleChange}
       />

--- a/src/components/atoms/TextAreaComponent.tsx
+++ b/src/components/atoms/TextAreaComponent.tsx
@@ -3,7 +3,7 @@ type Props = {
   name: string;
   value: string;
   placeholder?: string;
-  extraClassName?: string | undefined;
+  extraClassName?: string;
   handleChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
 };
 

--- a/src/components/atoms/TimePickerComponent.tsx
+++ b/src/components/atoms/TimePickerComponent.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
+import { twMerge } from 'tailwind-merge';
 
 type Props = {
   id: string;
@@ -18,6 +19,7 @@ export const TimePickerComponent = (props: Props) => {
     props.onChange && props.onChange(date);
   };
 
+  const baseClassName = 'w-full border border-gray-200 shadow-md text-base block p-1 h-12';
   return (
     <DatePicker
       timeFormat={'HH:mm'}
@@ -28,7 +30,7 @@ export const TimePickerComponent = (props: Props) => {
       timeIntervals={15}
       timeCaption={props.header}
       dateFormat='HH:mm'
-      className={props.extraClassName + ' ' + 'w-full border border-gray-200 shadow-md text-base block p-1 h-12'}
+      className={twMerge(baseClassName, props.extraClassName)}
     />
   );
 };

--- a/src/components/atoms/TimePickerComponent.tsx
+++ b/src/components/atoms/TimePickerComponent.tsx
@@ -7,7 +7,7 @@ type Props = {
   name: string;
   header: string;
   value: Date;
-  extraClassName?: string | undefined;
+  extraClassName?: string;
   setter: React.Dispatch<React.SetStateAction<Date>>;
   onChange?: (date: Date) => void;
 };


### PR DESCRIPTION
# 事前確認

-   [x] PR前に動作確認をしたか
-   [x] ビルドエラー/ESLintエラーは起きていないか
-   [x] [開発ルール](https://daydule.atlassian.net/wiki/spaces/DAYDULE/pages/9765029)を守って実装しているか

~-   [ ] 単体テストが全てOKになっているか~（現状はフロントエンドの単体テストを実行できていないため）

-   [x] 機密情報を含んでいないか
-   [x] 最新の`develop`ブランチを反映しているか

# レビュワーによる動作確認

- [x] @Mellbrother 
- [ ] @kzk27 

# やったこと<!-- このプルリクエストでやったことを書く -->

- tailwind-mergeを導入
- （ついで）CheckBoxComponentにあった不要なクラス指定を削除
- （ついで）next.config.jsによるリダイレクト設定を変更

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->
特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

「Tailwind CSSのクラス指定は、より左に書いたものが優先される」という認識が間違っていました。
本番環境でビルド時に必要なクラスのみを抽出しており、その時に開発環境とはクラスの優先度が変わってしまっていました。
そして、Tailwind CSSのクラス上書きにはtailwind-mergeというライブラリがあったのでそれを導入しました。

参考記事：https://zenn.dev/chot/articles/64cdfa4cb36917#%E3%83%AB%E3%83%BC%E3%83%AB%E3%81%9D%E3%81%AE%E5%8F%82%E3%80%81%E3%82%B9%E3%82%BF%E3%82%A4%E3%83%AB%E3%81%AE%E4%B8%8A%E6%9B%B8%E3%81%8D%E6%96%B9%E6%B3%95%E3%81%AB%E6%B3%A8%E6%84%8F%E3%81%99%E3%81%B9%E3%81%97

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

### 元々の「本番環境でスタイルが崩れる問題」の開発環境での再現方法&動作確認方法

1. .env.productionを一時的に以下に書き換える
```
NEXT_PUBLIC_API_BASE_URL=http://localhost:3000/
```
2. バックエンドを`make up`で起動する
3. フロントエンドで`npm i`を実行してライブラリをローカルにインストールする（以降はコンテナ内でもOK）
4. フロントエンドを`npm run build`でビルドする
5. フロントエンドを`npm start`で起動する
6. ログインする

### 今後の展望

参考記事にあるtailwind-variantsを導入したいですねー。
チケット起票しました。
https://daydule.atlassian.net/browse/DAYD-868
