### PR TITLE
DAYD-977 TODOの所要時間として自由な数字を設定できるようにする

### DIFF
--- a/src/components/common/leaf/SliderComponent.tsx
+++ b/src/components/common/leaf/SliderComponent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Range } from 'react-range';
 import { twMerge } from 'tailwind-merge';
 
@@ -13,14 +13,35 @@ type Props = {
 };
 
 const SliderComponent = (props: Props) => {
+  const [enteringNumbers, setEnteringNumbers] = useState<number>(30);
+  const [enteringNumbersFlag, setEnteringNumbersFlag] = useState<boolean>(false);
+
   const handleChange = (newValues: number[]) => {
     props.setter(newValues);
+  };
+  const enteringNumbersFunc = (flag: boolean) => {
+    setEnteringNumbersFlag(flag);
+    setEnteringNumbers(props?.values[0]);
+  };
+  const changeInput = (inputValue: string) => {
+    const inputNum = Number(inputValue);
+    if (isNaN(inputNum)) return;
+
+    if (inputNum > 120) {
+      handleChange([120]);
+    } else if (inputNum < 15) {
+      handleChange([15]);
+    } else {
+      handleChange([inputNum]);
+    }
+
+    setEnteringNumbers(inputNum);
   };
 
   return (
     <div className={twMerge('relative flex flex-col items-center', props.extraClassName)}>
       <Range
-        step={5}
+        step={1}
         min={props.min}
         max={props.max}
         values={props.values}
@@ -38,7 +59,15 @@ const SliderComponent = (props: Props) => {
       <div className='absolute -right-1 top-2'>{props.max}</div>
       <div className='mt-1'>
         <span>{props?.title + ' '}</span>
-        <span className='text-xl'>{props?.values[0]}</span>
+        <input
+          type='text'
+          inputMode='numeric'
+          className='w-8'
+          value={enteringNumbersFlag ? enteringNumbers : props?.values[0]}
+          onFocus={() => enteringNumbersFunc(true)}
+          onChange={(event) => changeInput(event.target.value)}
+          onBlur={() => enteringNumbersFunc(false)}
+        />
         <span>{props?.unit}</span>
       </div>
     </div>

--- a/src/components/features/main/tree/RegisterTodoComponent.tsx
+++ b/src/components/features/main/tree/RegisterTodoComponent.tsx
@@ -2,6 +2,7 @@ import { FormEvent, useState, useRef, useEffect } from 'react';
 import { SimpleInputComponent } from '@/components/common/leaf/SimpleInputComponent';
 import SliderComponent from '@/components/common/leaf/SliderComponent';
 import { ButtonComponent } from '@/components/common/tree/ButtonComponent';
+import { InfoIconComponent } from '@/components/common/tree/InfoIconComponent';
 import { RegisterTodoModalComponent } from '@/components/features/main/tree/RegisterTodoModalComponent';
 import { CONSTANT } from '@/constant/default';
 import { errorHandler } from '@/helpers/errorHandlerHelper';
@@ -14,17 +15,8 @@ type Props = {
 export const RegisterTodoComponent = (props: Props) => {
   const [title, setTitle] = useState<string>(CONSTANT.DEFAULT.PLAN.TITLE);
   const [processTime, setProcessTime] = useState<number[]>(CONSTANT.DEFAULT.PLAN.REGISTER_TODO.PROCESS_TIME);
-  const inputRef = useRef<HTMLInputElement>(null);
 
   const [createPlan] = useCreatePlanMutation();
-
-  useEffect(() => {
-    focusOnInput();
-  }, [inputRef]);
-
-  const focusOnInput = () => {
-    inputRef.current?.focus();
-  };
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     // これを入れているのは、リロードが走らないようにするため
@@ -59,7 +51,6 @@ export const RegisterTodoComponent = (props: Props) => {
       <form className='py-4' id='register-todo-form' onSubmit={handleSubmit}>
         <div className='mx-auto w-4/5'>
           <SimpleInputComponent
-            ref={inputRef}
             id='title'
             name='title'
             type='text'
@@ -69,7 +60,7 @@ export const RegisterTodoComponent = (props: Props) => {
             extraClassName='focus:outline-none'
           />
         </div>
-        <div className='inset-x-0 mx-auto mt-4 w-4/5' onClick={focusOnInput}>
+        <div className='inset-x-0 mx-auto mt-4 w-4/5'>
           <SliderComponent
             min={CONSTANT.DEFAULT.TODO.PROCESS_TIME_MIN}
             max={CONSTANT.DEFAULT.TODO.PROCESS_TIME_MAX}
@@ -78,6 +69,9 @@ export const RegisterTodoComponent = (props: Props) => {
             values={processTime}
             setter={setProcessTime}
           />
+          <div className='relative bottom-[21px] left-[205px] z-50 h-0'>
+            <InfoIconComponent content='所要時間は「最小15分」「最大120分」で入力してください。' />
+          </div>
         </div>
         <div className='mx-auto mt-4 w-4/5'>
           <ButtonComponent

--- a/src/components/features/main/tree/RegisterTodoModalComponent.tsx
+++ b/src/components/features/main/tree/RegisterTodoModalComponent.tsx
@@ -3,6 +3,7 @@ import { SimpleInputComponent } from '../../../common/leaf/SimpleInputComponent'
 import SliderComponent from '../../../common/leaf/SliderComponent';
 import { TextAreaComponent } from '../../../common/leaf/TextAreaComponent';
 import { ButtonComponent } from '../../../common/tree/ButtonComponent';
+import { InfoIconComponent } from '@/components/common/tree/InfoIconComponent';
 import { ModalComponent } from '@/components/common/tree/ModalComponent';
 import { CONSTANT } from '@/constant/default';
 import { errorHandler } from '@/helpers/errorHandlerHelper';
@@ -63,7 +64,7 @@ export const RegisterTodoModalComponent = (props: Props) => {
                 setter={props.setTitle}
               />
             </div>
-            <div className='mx-auto mt-2 flex w-4/5 items-center'>
+            <div className='mx-auto mt-2 flex w-full items-center'>
               <div className='mx-auto mt-8 w-4/5'>
                 <SliderComponent
                   min={CONSTANT.DEFAULT.TODO.PROCESS_TIME_MIN}
@@ -73,6 +74,9 @@ export const RegisterTodoModalComponent = (props: Props) => {
                   values={props.processTime}
                   setter={props.setProcessTime}
                 />
+                <div className='relative bottom-[21px] left-[195px] z-50 h-0'>
+                  <InfoIconComponent content='所要時間は「最小15分」「最大120分」で入力してください。' />
+                </div>
               </div>
             </div>
             <div className='ml-[13%] mt-4 flex'>

--- a/src/components/features/main/tree/TodoListComponent.tsx
+++ b/src/components/features/main/tree/TodoListComponent.tsx
@@ -103,7 +103,7 @@ export const TodoListComponent = () => {
           <TbArrowBigUpLines />
         </IconContext.Provider>
       </div>
-      <div className={'no-scrollbar absolute inset-0 top-12 overflow-y-auto pb-16'}>
+      <div className={'no-scrollbar absolute inset-0 top-12 pb-16'}>
         <DragDropContext onDragEnd={onDragEnd}>
           <Droppable droppableId='todoList'>
             {(provided, snapshot) => (

--- a/src/components/features/main/tree/UpdateTodoModalComponent.tsx
+++ b/src/components/features/main/tree/UpdateTodoModalComponent.tsx
@@ -3,6 +3,7 @@ import { SimpleInputComponent } from '../../../common/leaf/SimpleInputComponent'
 import SliderComponent from '../../../common/leaf/SliderComponent';
 import { TextAreaComponent } from '../../../common/leaf/TextAreaComponent';
 import { ButtonComponent } from '../../../common/tree/ButtonComponent';
+import { InfoIconComponent } from '@/components/common/tree/InfoIconComponent';
 import { ModalComponent } from '@/components/common/tree/ModalComponent';
 import { CONSTANT } from '@/constant/default';
 import { errorHandler } from '@/helpers/errorHandlerHelper';
@@ -65,7 +66,7 @@ export const UpdateTodoModalComponent = (props: Props) => {
               />
             </div>
             <div className='mx-auto mt-2 flex w-4/5 items-center'>
-              <div className='mx-auto mt-8 w-4/5'>
+              <div className='mx-auto mt-8 w-full'>
                 <SliderComponent
                   min={processTimeMin}
                   max={processTimeMax}
@@ -74,6 +75,9 @@ export const UpdateTodoModalComponent = (props: Props) => {
                   values={processTime}
                   setter={setProcessTime}
                 />
+                <div className='relative bottom-[21px] left-[195px] z-50 h-0'>
+                  <InfoIconComponent content='所要時間は「最小15分」「最大120分」で入力してください。' />
+                </div>
               </div>
             </div>
             <div className='ml-[13%] mt-4 flex'>


### PR DESCRIPTION
# 事前確認

- [x] PR 前に動作確認をしたか
- [x] ビルドエラー/ESLint エラーは起きていないか
- [x] [開発ルール](https://daydule.atlassian.net/wiki/spaces/DAYDULE/pages/9765029)を守って実装しているか

~- [ ] 単体テストが全て OK になっているか~（現状はフロントエンドの単体テストを実行できていないため）

- [x] 機密情報を含んでいないか
- [x] 最新の`develop`ブランチを反映しているか

# レビュー優先度（どれか一つ）

- [ ] すぐ見てもらいたい
- [ ] 3 日くらいで見てもらいたい
- [x] 7 日くらいで見てもらいたい

# レビューの度合い

- [ ] コードをぱっと確認してもらいたい
- [ ] コードをぱっと確認 & 動作確認してもらいたい
- [x] コードをしっかり確認 & 動作確認してもらいたい

# レビュワーによる動作確認

- [ ] @tom-takeru 
- [ ] @Mellbrother 
- [ ] @atoook 

# やったこと<!-- このプルリクエストでやったことを書く -->
- 所要時間をバーでの操作だけではなく、入力ボックスからユーザーが自由に数値を入力できるよう修正を行いました
    - 所要時間の入力は最小15分、最大120分となるためその情報をユーザーに知らせるためのTooltipを追加しました
        - ツールチップ導入にあたり既存のコード内にあるcssの記述を一部削除しております（コメントつけてます） 

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->
特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->
css修正に伴う既存コードへの影響

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->
特になし
